### PR TITLE
API host on .env file

### DIFF
--- a/src/config/airbrake.php
+++ b/src/config/airbrake.php
@@ -32,7 +32,7 @@ return [
    */
   'connection'          => [
 
-    'host'      => 'api.airbrake.io',
+    'host'      => env('AIRBRAKE_API_HOST','api.airbrake.io'),
 
     'port'      => '443',
 


### PR DESCRIPTION
Hi,

This would be usefull for those who want to use Errbit.
Now we can just add on the .env file AIRBRAKE_API_HOST the Errbit host!
